### PR TITLE
feat: add transaction amount distribution analysis sheet

### DIFF
--- a/.changeset/rich-trains-hang.md
+++ b/.changeset/rich-trains-hang.md
@@ -1,0 +1,5 @@
+---
+"mpesa2csv": patch
+---
+
+fix: reset/skip options after upload

--- a/.changeset/tricky-wasps-stare.md
+++ b/.changeset/tricky-wasps-stare.md
@@ -1,0 +1,5 @@
+---
+"mpesa2csv": minor
+---
+
+feat: Add Transaction Amount Distribution Sheet

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.7
+        version: 2.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tailwindcss/vite':
         specifier: ^4.1.3
         version: 4.1.13(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1))
@@ -651,6 +657,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
     peerDependencies:
@@ -723,6 +742,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -2665,6 +2697,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.13
 
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2747,6 +2788,26 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.13
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.13)(react@19.1.1)':
     dependencies:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "mpesa2csv - Convert M-PESA Statements to CSV/Excel",
-        "width": 600,
-        "height": 630,
+        "width": 640,
+        "height": 600,
         "minWidth": 500,
         "minHeight": 400,
         "resizable": true
@@ -64,7 +64,7 @@
         },
         "windowSize": {
           "width": 660,
-          "height": 630
+          "height": 600
         }
       }
     },

--- a/src/components/export-options.tsx
+++ b/src/components/export-options.tsx
@@ -1,0 +1,127 @@
+import { ExportFormat, ExportOptions as ExportOptionsType } from "../types";
+import { ExportService } from "../services/exportService";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import { Checkbox } from "./ui/checkbox";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
+import { Label } from "./ui/label";
+import { Info } from "lucide-react";
+
+interface ExportOptionsProps {
+  exportFormat: ExportFormat;
+  exportOptions: ExportOptionsType;
+  onFormatChange: (format: ExportFormat) => void;
+  onOptionsChange: (options: ExportOptionsType) => void;
+}
+
+// Sheet option configuration with short names and descriptions
+const SHEET_OPTIONS = [
+  {
+    key: "includeChargesSheet" as keyof ExportOptionsType,
+    name: "Charges & Fees",
+    description: "Separate sheet with all transaction charges and fees",
+  },
+  {
+    key: "includeSummarySheet" as keyof ExportOptionsType,
+    name: "Financial Summary",
+    description:
+      "Comprehensive financial analysis with cash flow, spending patterns, and insights",
+  },
+  {
+    key: "includeBreakdownSheet" as keyof ExportOptionsType,
+    name: "Monthly & Weekly Breakdown",
+    description:
+      "Pivot-like table with monthly and weekly aggregations showing inflows, outflows, net change, and average transaction size",
+  },
+  {
+    key: "includeDailyBalanceSheet" as keyof ExportOptionsType,
+    name: "Daily Balance Tracker",
+    description:
+      "Day-by-day balance tracker showing highest and lowest balances with spending pattern insights",
+  },
+  {
+    key: "includeAmountDistributionSheet" as keyof ExportOptionsType,
+    name: "Transaction Amount Distribution",
+    description:
+      "Groups transactions by amount ranges (e.g., <100 KES, 100-500 KES, >500 KES), showing counts, totals, and percentages for inflows and outflows separately. Excludes charges and fees.",
+  },
+];
+
+export default function ExportOptions({
+  exportFormat,
+  exportOptions,
+  onFormatChange,
+  onOptionsChange,
+}: ExportOptionsProps) {
+  const handleFormatChange = (value: ExportFormat) => {
+    onFormatChange(value);
+  };
+
+  const handleOptionChange = (
+    optionKey: keyof ExportOptionsType,
+    value: boolean
+  ) => {
+    const newOptions = {
+      ...exportOptions,
+      [optionKey]: value,
+    };
+    onOptionsChange(newOptions);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label className="block text-sm font-medium mb-2">Export Format</Label>
+        <Select value={exportFormat} onValueChange={handleFormatChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select export format">
+              {ExportService.getFormatDisplayName(exportFormat)}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {ExportService.getAllFormats().map((format) => (
+              <SelectItem key={format} value={format}>
+                {ExportService.getFormatDisplayName(format)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {exportFormat === ExportFormat.XLSX && (
+        <div>
+          <Label className="block text-sm font-medium mb-3">
+            Additional Sheets
+          </Label>
+          <div className="grid grid-cols-1 gap-3">
+            {SHEET_OPTIONS.map((option) => (
+              <div key={option.key} className="flex items-center space-x-2">
+                <Checkbox
+                  checked={exportOptions[option.key] || false}
+                  onCheckedChange={(value) =>
+                    handleOptionChange(option.key, Boolean(value))
+                  }
+                  className="rounded border-gray-300 text-primary focus:ring-primary"
+                />
+                <Label className="flex-1 text-sm">{option.name}</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="w-4 h-4 text-gray-400 hover:text-gray-600 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    <p>{option.description}</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -7,6 +7,8 @@ import { Button } from "./ui/button";
 
 interface PasswordPromptProps {
   onPasswordSubmit: (password: string) => void;
+  onSkip?: () => void;
+  onReset?: () => void;
   status: FileStatus;
   error?: string;
   currentFileName?: string;
@@ -16,6 +18,8 @@ interface PasswordPromptProps {
 
 const PasswordPrompt: React.FC<PasswordPromptProps> = ({
   onPasswordSubmit,
+  onSkip,
+  onReset,
   status,
   error,
   currentFileName,
@@ -87,6 +91,34 @@ const PasswordPrompt: React.FC<PasswordPromptProps> = ({
               "Unlock PDF"
             )}
           </Button>
+
+          {/* Skip and Reset buttons */}
+          <div className="flex gap-2 mt-3">
+            {onSkip && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                className="flex-1 text-foreground"
+                onClick={onSkip}
+                disabled={status === FileStatus.PROCESSING}
+              >
+                Skip File
+              </Button>
+            )}
+            {onReset && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                className="flex-1 text-foreground"
+                onClick={onReset}
+                disabled={status === FileStatus.PROCESSING}
+              >
+                Restart
+              </Button>
+            )}
+          </div>
         </div>
       </form>
 

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/services/exports/index.ts
+++ b/src/services/exports/index.ts
@@ -2,3 +2,4 @@ export { addChargesSheet } from "./chargesSheet";
 export { addFinancialSummarySheet } from "./financialSummarySheet";
 export { addMonthlyWeeklyBreakdownSheet } from "./monthlyWeeklyBreakdownSheet";
 export { addDailyBalanceTrackerSheet } from "./dailyBalanceTrackerSheet";
+export { addTransactionAmountDistributionSheet } from "./transactionAmountDistributionSheet";

--- a/src/services/exports/transactionAmountDistributionSheet.ts
+++ b/src/services/exports/transactionAmountDistributionSheet.ts
@@ -1,0 +1,267 @@
+import { MPesaStatement } from "../../types";
+import * as ExcelJS from "exceljs";
+
+interface SizeDistributionBucket {
+  range: string;
+  minAmount: number;
+  maxAmount: number | null;
+  inflowCount: number;
+  inflowTotal: number;
+  inflowPercentage: number;
+  outflowCount: number;
+  outflowTotal: number;
+  outflowPercentage: number;
+}
+
+interface SizeDistributionSummary {
+  totalInflows: number;
+  totalOutflows: number;
+  totalInflowTransactions: number;
+  totalOutflowTransactions: number;
+  buckets: SizeDistributionBucket[];
+}
+
+export function addTransactionAmountDistributionSheet(
+  workbook: ExcelJS.Workbook,
+  statement: MPesaStatement
+): void {
+  // Filter out charge transactions for this analysis
+  const nonChargeTransactions = statement.transactions.filter(
+    (transaction) => !transaction.details.toLowerCase().includes("charge")
+  );
+
+  if (nonChargeTransactions.length === 0) {
+    return; // No non-charge transactions found, don't create the sheet
+  }
+
+  // Calculate size distribution
+  const sizeDistribution = calculateSizeDistribution(nonChargeTransactions);
+
+  // Create the worksheet
+  const worksheet = workbook.addWorksheet("Transaction Amount Distribution");
+
+  // Add title
+  worksheet.mergeCells("A1:I1");
+  const titleCell = worksheet.getCell("A1");
+  titleCell.value = "Transaction Amount Distribution Analysis";
+  titleCell.font = { bold: true, size: 16 };
+  titleCell.alignment = { horizontal: "center" };
+  titleCell.fill = {
+    type: "pattern",
+    pattern: "solid",
+    fgColor: { argb: "FF4472C4" },
+  };
+
+  // Add subtitle
+  worksheet.mergeCells("A2:I2");
+  const subtitleCell = worksheet.getCell("A2");
+  subtitleCell.value = "Excludes transaction charges and fees";
+  subtitleCell.font = { italic: true, size: 12 };
+  subtitleCell.alignment = { horizontal: "center" };
+
+  // Set up headers starting from row 4
+  const headerRow = 4;
+  const headers = [
+    "Amount Range",
+    "Inflow Count",
+    "Inflow Total (KES)",
+    "Inflow %",
+    "Outflow Count",
+    "Outflow Total (KES)",
+    "Outflow %",
+    "Total Count",
+    "Total Amount (KES)",
+  ];
+
+  headers.forEach((header, index) => {
+    const cell = worksheet.getCell(headerRow, index + 1);
+    cell.value = header;
+    cell.font = { bold: true };
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: "FFE0E0E0" },
+    };
+    cell.alignment = { horizontal: "center" };
+  });
+
+  // Add data rows
+  let currentRow = headerRow + 1;
+  sizeDistribution.buckets.forEach((bucket) => {
+    const totalCount = bucket.inflowCount + bucket.outflowCount;
+    const totalAmount = bucket.inflowTotal + bucket.outflowTotal;
+
+    worksheet.getCell(currentRow, 1).value = bucket.range;
+    worksheet.getCell(currentRow, 2).value = bucket.inflowCount;
+    worksheet.getCell(currentRow, 3).value = bucket.inflowTotal;
+    worksheet.getCell(currentRow, 4).value = `${bucket.inflowPercentage.toFixed(
+      1
+    )}%`;
+    worksheet.getCell(currentRow, 5).value = bucket.outflowCount;
+    worksheet.getCell(currentRow, 6).value = bucket.outflowTotal;
+    worksheet.getCell(
+      currentRow,
+      7
+    ).value = `${bucket.outflowPercentage.toFixed(1)}%`;
+    worksheet.getCell(currentRow, 8).value = totalCount;
+    worksheet.getCell(currentRow, 9).value = totalAmount;
+
+    // Format currency cells
+    worksheet.getCell(currentRow, 3).numFmt = "#,##0.00";
+    worksheet.getCell(currentRow, 6).numFmt = "#,##0.00";
+    worksheet.getCell(currentRow, 9).numFmt = "#,##0.00";
+
+    currentRow++;
+  });
+
+  // Add summary section
+  currentRow += 2;
+  worksheet.mergeCells(`A${currentRow}:I${currentRow}`);
+  const summaryTitleCell = worksheet.getCell(`A${currentRow}`);
+  summaryTitleCell.value = "Summary";
+  summaryTitleCell.font = { bold: true, size: 14 };
+  summaryTitleCell.fill = {
+    type: "pattern",
+    pattern: "solid",
+    fgColor: { argb: "FFFFD700" },
+  };
+
+  currentRow++;
+  worksheet.getCell(currentRow, 1).value = "Total Inflow Transactions:";
+  worksheet.getCell(currentRow, 2).value =
+    sizeDistribution.totalInflowTransactions;
+  worksheet.getCell(currentRow, 1).font = { bold: true };
+
+  currentRow++;
+  worksheet.getCell(currentRow, 1).value = "Total Inflow Amount:";
+  worksheet.getCell(currentRow, 2).value = sizeDistribution.totalInflows;
+  worksheet.getCell(currentRow, 2).numFmt = "#,##0.00";
+  worksheet.getCell(currentRow, 1).font = { bold: true };
+
+  currentRow++;
+  worksheet.getCell(currentRow, 1).value = "Total Outflow Transactions:";
+  worksheet.getCell(currentRow, 2).value =
+    sizeDistribution.totalOutflowTransactions;
+  worksheet.getCell(currentRow, 1).font = { bold: true };
+
+  currentRow++;
+  worksheet.getCell(currentRow, 1).value = "Total Outflow Amount:";
+  worksheet.getCell(currentRow, 2).value = sizeDistribution.totalOutflows;
+  worksheet.getCell(currentRow, 2).numFmt = "#,##0.00";
+  worksheet.getCell(currentRow, 1).font = { bold: true };
+
+  // Set column widths
+  worksheet.columns = [
+    { width: 20 }, // Amount Range
+    { width: 12 }, // Inflow Count
+    { width: 18 }, // Inflow Total
+    { width: 10 }, // Inflow %
+    { width: 12 }, // Outflow Count
+    { width: 18 }, // Outflow Total
+    { width: 10 }, // Outflow %
+    { width: 12 }, // Total Count
+    { width: 18 }, // Total Amount
+  ];
+
+  // Add borders to all data cells
+  const dataRange = worksheet.getRows(headerRow, currentRow);
+  if (dataRange) {
+    dataRange.forEach((row) => {
+      if (row) {
+        row.eachCell((cell) => {
+          cell.border = {
+            top: { style: "thin" },
+            left: { style: "thin" },
+            bottom: { style: "thin" },
+            right: { style: "thin" },
+          };
+        });
+      }
+    });
+  }
+}
+
+function calculateSizeDistribution(
+  transactions: any[]
+): SizeDistributionSummary {
+  // Define amount ranges (in KES)
+  const ranges = [
+    { range: "< 100 KES", minAmount: 0, maxAmount: 99.99 },
+    { range: "100 - 500 KES", minAmount: 100, maxAmount: 500 },
+    { range: "501 - 1,000 KES", minAmount: 501, maxAmount: 1000 },
+    { range: "1,001 - 5,000 KES", minAmount: 1001, maxAmount: 5000 },
+    { range: "5,001 - 10,000 KES", minAmount: 5001, maxAmount: 10000 },
+    { range: "10,001 - 50,000 KES", minAmount: 10001, maxAmount: 50000 },
+    { range: "> 50,000 KES", minAmount: 50001, maxAmount: null },
+  ];
+
+  // Initialize buckets
+  const buckets: SizeDistributionBucket[] = ranges.map((range) => ({
+    range: range.range,
+    minAmount: range.minAmount,
+    maxAmount: range.maxAmount,
+    inflowCount: 0,
+    inflowTotal: 0,
+    inflowPercentage: 0,
+    outflowCount: 0,
+    outflowTotal: 0,
+    outflowPercentage: 0,
+  }));
+
+  let totalInflows = 0;
+  let totalOutflows = 0;
+  let totalInflowTransactions = 0;
+  let totalOutflowTransactions = 0;
+
+  // Process each transaction
+  transactions.forEach((transaction) => {
+    const amount = Math.abs(transaction.paidIn || transaction.withdrawn || 0);
+    const isInflow = transaction.paidIn !== null && transaction.paidIn > 0;
+    const isOutflow =
+      transaction.withdrawn !== null && transaction.withdrawn > 0;
+
+    if (!isInflow && !isOutflow) return;
+
+    // Find the appropriate bucket
+    const bucket = buckets.find((b) => {
+      if (b.maxAmount === null) {
+        return amount >= b.minAmount;
+      }
+      return amount >= b.minAmount && amount <= b.maxAmount;
+    });
+
+    if (bucket) {
+      if (isInflow) {
+        bucket.inflowCount++;
+        bucket.inflowTotal += amount;
+        totalInflows += amount;
+        totalInflowTransactions++;
+      } else if (isOutflow) {
+        bucket.outflowCount++;
+        bucket.outflowTotal += amount;
+        totalOutflows += amount;
+        totalOutflowTransactions++;
+      }
+    }
+  });
+
+  // Calculate percentages
+  buckets.forEach((bucket) => {
+    bucket.inflowPercentage =
+      totalInflowTransactions > 0
+        ? (bucket.inflowCount / totalInflowTransactions) * 100
+        : 0;
+    bucket.outflowPercentage =
+      totalOutflowTransactions > 0
+        ? (bucket.outflowCount / totalOutflowTransactions) * 100
+        : 0;
+  });
+
+  return {
+    totalInflows,
+    totalOutflows,
+    totalInflowTransactions,
+    totalOutflowTransactions,
+    buckets,
+  };
+}

--- a/src/services/xlsxService.ts
+++ b/src/services/xlsxService.ts
@@ -5,6 +5,7 @@ import {
   addFinancialSummarySheet,
   addMonthlyWeeklyBreakdownSheet,
   addDailyBalanceTrackerSheet,
+  addTransactionAmountDistributionSheet,
 } from "./exports";
 
 export class XlsxService {
@@ -92,6 +93,11 @@ export class XlsxService {
     // Add Daily Balance Tracker sheet if requested
     if (options?.includeDailyBalanceSheet) {
       addDailyBalanceTrackerSheet(workbook, statement);
+    }
+
+    // Add Transaction Amount Distribution sheet if requested
+    if (options?.includeAmountDistributionSheet) {
+      addTransactionAmountDistributionSheet(workbook, statement);
     }
 
     const buffer = await workbook.xlsx.writeBuffer();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,4 +33,5 @@ export interface ExportOptions {
   includeSummarySheet?: boolean;
   includeBreakdownSheet?: boolean;
   includeDailyBalanceSheet?: boolean;
+  includeAmountDistributionSheet?: boolean;
 }


### PR DESCRIPTION
## Description

This PR adds an optional transaction amount distribution sheet which Groups transactions by amount ranges (e.g., <100 KES, 100-500 KES, >500 KES), showing counts, totals, and percentages for inflows and outflows separately. This excludes charges and fees.

Fixes # (issue)

- Added Reset/Skip Options in Password Prompt
- Updated Layout to have Export Option description in a tooltip.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Dependency update


**Test Configuration:**

- OS: (e.g., Windows 11, macOS 14, Ubuntu 22.04)
- Node version: (e.g., 18.17.0)
- pnpm version: (e.g., 8.6.0)

## Screenshots (if applicable)

<img width="1652" height="1572" alt="CleanShot 2025-09-27 at 6  33 30@2x" src="https://github.com/user-attachments/assets/e11a5bec-2130-4710-b1ab-c3fbce7e8ffa" />

<img width="1608" height="676" alt="CleanShot 2025-09-27 at 6  29 21@2x" src="https://github.com/user-attachments/assets/5c660d38-d2cd-409a-b8de-8cfb62aff568" />
