### PR TITLE
fix: datetime parsing for paybill statements

### DIFF
--- a/.changeset/fresh-lies-post.md
+++ b/.changeset/fresh-lies-post.md
@@ -1,0 +1,5 @@
+---
+"mpesa2csv": patch
+---
+
+fix: datetime parsing for paybill statements

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "mpesa2csv"
-version = "0.5.0"
+version = "0.5.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,8 +29,8 @@ export enum ExportFormat {
 }
 
 export enum SortOrder {
-  DESC="desc",
-  ASC="asc",
+  DESC = "desc",
+  ASC = "asc",
 }
 
 export interface ExportOptions {


### PR DESCRIPTION
## Description

This PR properly parses the datetime in paybill statements , it also does a dirty exclusion of the the disclaimer footer at the end of details parsing if it exists.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Dependency update

