### PR TITLE
fix: password-protected PDFs and cleaner release notes

### DIFF
--- a/.changeset/chore-professional-release-notes.md
+++ b/.changeset/chore-professional-release-notes.md
@@ -1,0 +1,5 @@
+---
+"mpesa2csv": patch
+---
+
+Make changelog and GitHub release notes more professional by dropping author “Thanks!” attributions, using summary-first entries, and simplifying the release body.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,8 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "DavidAmunga/mpesa2csv"
+      "repo": "DavidAmunga/mpesa2csv",
+      "template": "\n\n- {summary} {ref}"
     }
   ],
   "commit": false,

--- a/.changeset/fix-password-protected-pdf-extraction.md
+++ b/.changeset/fix-password-protected-pdf-extraction.md
@@ -1,0 +1,5 @@
+---
+"mpesa2csv": patch
+---
+
+Fix password-protected PDFs failing with an empty Tabula error instead of showing the unlock prompt, by capturing Java stderr/stdout and improving password-error detection and the protected-file UI.

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -551,73 +551,46 @@ jobs:
         shell: bash
         continue-on-error: false
         run: |
-          set +e  # Disable exit on error for this script
+          set +e
           VERSION="${{ needs.prepare-release.outputs.version }}"
 
           if [ -f "CHANGELOG.md" ]; then
-            # Extract the changelog section for the current version
+            # Extract this version's section; drop Changesets category headings
+            # so GitHub release notes read as a clean bullet list.
             CHANGELOG_CONTENT=$(awk -v version="$VERSION" '
-              /^## / { 
+              /^## / {
                 if (found) exit
                 if ($0 ~ "## .*" version) found=1
                 next
               }
               found && /^## / { exit }
+              found && /^### / { next }
               found { print }
-            ' CHANGELOG.md | sed '/^$/d' | head -30)
-            
-            # Get previous version for comparison link
+            ' CHANGELOG.md | sed '/^[[:space:]]*$/d')
+
             PREVIOUS_VERSION=$(awk '/^## / && !/'"$VERSION"'/ { print $2; exit }' CHANGELOG.md)
-            
+
             if [ -n "$CHANGELOG_CONTENT" ]; then
-              # Analyze change types - handle both "feat:" and "hash: feat:" formats
-              FEATURES=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?feat:" | wc -l | tr -d ' ')
-              FIXES=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?fix:" | wc -l | tr -d ' ')
-              BREAKING=$(echo "$CHANGELOG_CONTENT" | grep -E "BREAKING CHANGE|!" | wc -l | tr -d ' ')
-              DOCS=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?docs:" | wc -l | tr -d ' ')
-              PERF=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?perf:" | wc -l | tr -d ' ')
-              REFACTOR=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?refactor:" | wc -l | tr -d ' ')
-              CHORE=$(echo "$CHANGELOG_CONTENT" | grep -E "(^- [a-f0-9]+: )?chore:" | wc -l | tr -d ' ')
-              SECURITY=$(echo "$CHANGELOG_CONTENT" | grep -i "security\|vulnerability\|cve\|exploit" | wc -l | tr -d ' ')
-              
-              # Count total changes
-              TOTAL_CHANGES=$(echo "$CHANGELOG_CONTENT" | grep "^-" | wc -l | tr -d ' ')
-              
-              FORMATTED_CHANGELOG="$CHANGELOG_CONTENT"
-              
-              # Sanitize: remove all control characters except newline, escape backslashes and quotes
-              FORMATTED_CHANGELOG=$(printf '%s' "$FORMATTED_CHANGELOG" | LC_ALL=C tr -d '\000-\011\013-\037\177' | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
-              
+              HAS_BREAKING="false"
+              if echo "$CHANGELOG_CONTENT" | grep -qiE 'breaking change|BREAKING'; then
+                HAS_BREAKING="true"
+              fi
+
+              FORMATTED_CHANGELOG=$(printf '%s' "$CHANGELOG_CONTENT" | LC_ALL=C tr -d '\000-\011\013-\037\177' | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+
               echo "changelog<<EOF" >> $GITHUB_OUTPUT
               printf '%s\n' "$FORMATTED_CHANGELOG" >> $GITHUB_OUTPUT
               echo "EOF" >> $GITHUB_OUTPUT
-              
-              # Output change statistics
-              echo "features=$FEATURES" >> $GITHUB_OUTPUT
-              echo "fixes=$FIXES" >> $GITHUB_OUTPUT
-              echo "breaking=$BREAKING" >> $GITHUB_OUTPUT
-              echo "docs=$DOCS" >> $GITHUB_OUTPUT
-              echo "perf=$PERF" >> $GITHUB_OUTPUT
-              echo "refactor=$REFACTOR" >> $GITHUB_OUTPUT
-              echo "security=$SECURITY" >> $GITHUB_OUTPUT
-              echo "total_changes=$TOTAL_CHANGES" >> $GITHUB_OUTPUT
+              echo "has_breaking=$HAS_BREAKING" >> $GITHUB_OUTPUT
             else
               echo "changelog=See CHANGELOG.md for details." >> $GITHUB_OUTPUT
-              echo "features=0" >> $GITHUB_OUTPUT
-              echo "fixes=0" >> $GITHUB_OUTPUT
-              echo "breaking=0" >> $GITHUB_OUTPUT
-              echo "security=0" >> $GITHUB_OUTPUT
-              echo "total_changes=0" >> $GITHUB_OUTPUT
+              echo "has_breaking=false" >> $GITHUB_OUTPUT
             fi
             echo "previous_version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
           else
             echo "changelog=No changelog available." >> $GITHUB_OUTPUT
             echo "previous_version=0.0.2" >> $GITHUB_OUTPUT
-            echo "features=0" >> $GITHUB_OUTPUT
-            echo "fixes=0" >> $GITHUB_OUTPUT
-            echo "breaking=0" >> $GITHUB_OUTPUT
-            echo "security=0" >> $GITHUB_OUTPUT
-            echo "total_changes=0" >> $GITHUB_OUTPUT
+            echo "has_breaking=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate build timestamp
@@ -948,55 +921,25 @@ jobs:
           tag_name: ${{ needs.prepare-release.outputs.tag }}
           name: "mpesa2csv ${{ needs.prepare-release.outputs.tag }}"
           body: |
-            ## What's New in v${{ needs.prepare-release.outputs.version }}
+            ## Changes
 
-            ${{ steps.changelog.outputs.total_changes > 0 && format('📊 **Release Summary**: {0} changes', steps.changelog.outputs.total_changes) || '' }}
-
-            ${{ steps.changelog.outputs.breaking > 0 && '> ⚠️ **BREAKING CHANGES**: This release contains breaking changes. Please review the changelog carefully before updating.' || '' }}
-
-            ${{ steps.changelog.outputs.security > 0 && '> 🔒 **SECURITY UPDATE**: This release includes important security fixes. We recommend updating as soon as possible.' || '' }}
+            ${{ steps.changelog.outputs.has_breaking == 'true' && '> **Breaking changes** — review the notes below before updating.' || '' }}
 
             ${{ steps.changelog.outputs.changelog }}
 
-            ${{ steps.changelog.outputs.features > 0 && steps.changelog.outputs.fixes > 0 && format('🎯 **Highlights**: This release brings {0} new features and fixes {1} bugs for a better user experience.', steps.changelog.outputs.features, steps.changelog.outputs.fixes) || '' }}
-            ${{ steps.changelog.outputs.features > 0 && steps.changelog.outputs.fixes == 0 && format('✨ **Feature Release**: Introducing {0} new features to enhance your workflow.', steps.changelog.outputs.features) || '' }}
-            ${{ steps.changelog.outputs.features == 0 && steps.changelog.outputs.fixes > 0 && format('🔧 **Maintenance Release**: This update focuses on stability with {0} bug fixes.', steps.changelog.outputs.fixes) || '' }}
+            ## Downloads
 
-            ---
+            | Platform | Architecture | File |
+            |----------|--------------|------|
+            | Windows | x64 | [Installer (.exe)](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_x64-setup.exe) |
+            | macOS | Apple Silicon | [Disk image (.dmg)](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_aarch64.dmg) |
+            | macOS | Intel | [Disk image (.dmg)](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_x64.dmg) |
+            | Linux | x64 | [Debian package (.deb)](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_amd64.deb) |
+            | Linux | x64 | [AppImage](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_amd64.AppImage) |
 
-            ## 📥 Download & Installation
+            Built `${{ steps.timestamp.outputs.build_time }}`. Installed copies can update automatically when this release is available.
 
-            Choose the appropriate download for your platform:
-
-            | Platform | Architecture | Download | Installation |
-            |----------|-------------|----------|--------------|
-            | **Windows** | x64 (Intel/AMD) | [📥 Download .exe](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_x64-setup.exe) | Run the installer and follow the setup wizard |
-            | **macOS** | Apple Silicon (M1/M2/M3) | [📥 Download .dmg](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_aarch64.dmg) | Open DMG and drag to Applications |
-            | **macOS** | Intel x64 | [📥 Download .dmg](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_x64.dmg) | Open DMG and drag to Applications |
-            | **Linux** | x64 (Ubuntu/Debian) | [📥 Download .deb](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_amd64.deb) | `sudo dpkg -i mpesa2csv_*.deb` |
-            | **Linux** | x64 (Portable) | [📥 Download .AppImage](https://github.com/DavidAmunga/mpesa2csv/releases/download/${{ needs.prepare-release.outputs.tag }}/mpesa2csv_${{ needs.prepare-release.outputs.version }}_amd64.AppImage) | `chmod +x mpesa2csv_*.AppImage && ./mpesa2csv_*.AppImage` |
-
-            ### 📊 Release Metadata
-
-            - **Version**: `${{ needs.prepare-release.outputs.version }}`
-            - **Build Date**: `${{ steps.timestamp.outputs.build_time }}`
-            - **Total Changes**: ${{ steps.changelog.outputs.total_changes }}
-            - **Platforms**: Windows, macOS (Intel + Apple Silicon), Linux
-            ${{ steps.changelog.outputs.breaking > 0 && format('- **Breaking Changes**: {0}', steps.changelog.outputs.breaking) || '' }}
-
-            ### 🔍 System Requirements
-
-            - **Windows**: Windows 10 version 1903 or later
-            - **macOS**: macOS 10.15 Catalina or later  
-            - **Linux**: Modern distribution with GTK 3.24+ and WebKit2GTK 4.1+
-
-            ### 🔄 Auto-Update
-
-            > **Note**: If you have a previous version installed, the app will automatically notify you when this update is available and guide you through the update process.
-
-            ---
-
-            **Full Changelog**: https://github.com/${{ github.repository }}/compare/v${{ steps.changelog.outputs.previous_version || '0.0.2' }}...v${{ needs.prepare-release.outputs.version }}
+            **Full changelog:** https://github.com/${{ github.repository }}/compare/v${{ steps.changelog.outputs.previous_version || '0.0.2' }}...v${{ needs.prepare-release.outputs.version }}
           draft: false
           prerelease: false
           files: |

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,17 @@
+## Design Context
+
+### Users
+A mix of individuals exporting their own M-PESA statements, accountants/bookkeepers batching client files, and small-business owners. They use the app locally to turn password-protected statement PDFs into CSV/Excel for analysis, accounting, or record-keeping. The unlock step is a brief gate on the way to that job — not the product itself.
+
+### Brand Personality
+Private, green, no-nonsense. The interface should feel calm and trustworthy: clear, local-first, and free of hype. Reassure without theatrics; never imply cloud sync or remote access.
+
+### Aesthetic Direction
+Calm / trustworthy utility. Preserve the existing green primary and light/dark theme support. Prefer quiet composition, clear hierarchy, and purposeful motion over decorative chrome. Anti-references: generic yellow lock-in-rounded-square templates, neon “security” aesthetics, purple/cyan AI gradients, glassmorphism for its own sake, and busy card stacks.
+
+### Design Principles
+1. **Trust through clarity** — Say what happens and where the password goes; keep privacy cues factual and short.
+2. **Calm progress** — One focused action (unlock); secondary exits stay quiet.
+3. **Local-first privacy** — Reinforce that decryption stays on-device without alarmist language.
+4. **No-nonsense hierarchy** — Filename, password field, primary CTA; skip noise and repeated copy.
+5. **Cohesive green utility** — Use the product green for action and trust accents; neutrals carry the rest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,96 +4,96 @@
 
 ### Patch Changes
 
-- [#72](https://github.com/davidamunga/mpesa2csv/pull/72) [`ac87b5a`](https://github.com/davidamunga/mpesa2csv/commit/ac87b5abcc00846028abfea8a19fe0374de822bd) Thanks [@davidamunga](https://github.com/davidamunga)! - Resolve the `brace-expansion` DoS advisory (GHSA-mh99-v99m-4gvg) by overriding the transitive exceljs dependency to a patched release so CI security audits pass.
+- Resolve the `brace-expansion` DoS advisory (GHSA-mh99-v99m-4gvg) by overriding the transitive exceljs dependency to a patched release so CI security audits pass. ([#72](https://github.com/davidamunga/mpesa2csv/pull/72))
 
-- [#72](https://github.com/davidamunga/mpesa2csv/pull/72) [`ae99570`](https://github.com/davidamunga/mpesa2csv/commit/ae9957058b7f9d47a4a5fa246cd9282f7958600f) Thanks [@davidamunga](https://github.com/davidamunga)! - Fix macOS auto-updates failing on Apple Silicon by publishing separate aarch64 and x86_64 updater archives, and pointing `latest.json` at the matching artifact for each architecture.
+- Fix macOS auto-updates failing on Apple Silicon by publishing separate aarch64 and x86_64 updater archives, and pointing `latest.json` at the matching artifact for each architecture. ([#72](https://github.com/davidamunga/mpesa2csv/pull/72))
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#70](https://github.com/davidamunga/mpesa2csv/pull/70) [`9e0ac87`](https://github.com/davidamunga/mpesa2csv/commit/9e0ac873f21a1fb7e76099a3ed34f3e0caa10527) Thanks [@davidamunga](https://github.com/davidamunga)! - Success screen now shows a financial snapshot — date range covered, total money in, total money out, and charges — all derived from the parsed statement before you export. Window height reduced from 850 → 650px, footer simplified to a single line, and dead-zone layout issues resolved.
+- Success screen now shows a financial snapshot — date range covered, total money in, total money out, and charges — all derived from the parsed statement before you export. Window height reduced from 850 → 650px, footer simplified to a single line, and dead-zone layout issues resolved. ([#70](https://github.com/davidamunga/mpesa2csv/pull/70))
 
 ### Patch Changes
 
-- [#69](https://github.com/davidamunga/mpesa2csv/pull/69) [`0395f66`](https://github.com/davidamunga/mpesa2csv/commit/0395f66944e52e8514257f1a81a8adfee8cdba88) Thanks [@davidamunga](https://github.com/davidamunga)! - Reduce initial JS bundle from 1 466 kB to 487 kB (−67%) by removing 10 unused packages, lazy-loading ExcelJS via dynamic import
+- Reduce initial JS bundle from 1 466 kB to 487 kB (−67%) by removing 10 unused packages, lazy-loading ExcelJS via dynamic import ([#69](https://github.com/davidamunga/mpesa2csv/pull/69))
 
-- [#70](https://github.com/davidamunga/mpesa2csv/pull/70) [`6c45724`](https://github.com/davidamunga/mpesa2csv/commit/6c45724c32db6fb9d2b54f2af3468af7b8eb3690) Thanks [@davidamunga](https://github.com/davidamunga)! - improved success state ui
+- improved success state ui ([#70](https://github.com/davidamunga/mpesa2csv/pull/70))
 
 ## 0.14.0
 
 ### Minor Changes
 
-- [#67](https://github.com/davidamunga/mpesa2csv/pull/67) [`159e467`](https://github.com/davidamunga/mpesa2csv/commit/159e467a4672cdf425a3b4abcc83a6151edde763) Thanks [@davidamunga](https://github.com/davidamunga)! - - Clickable drop zone
-  - Cancel button during processing
-  - Transaction preview before export
-  - Re-export without Start Again
-  - XLSX blob only on Export click
-  - Visible webhook result badge.
+- - Clickable drop zone ([#67](https://github.com/davidamunga/mpesa2csv/pull/67))
+ - Cancel button during processing
+ - Transaction preview before export
+ - Re-export without Start Again
+ - XLSX blob only on Export click
+ - Visible webhook result badge.
 
 ### Patch Changes
 
-- [#65](https://github.com/davidamunga/mpesa2csv/pull/65) [`65c8984`](https://github.com/davidamunga/mpesa2csv/commit/65c8984b738ad2b2d67b8f3dcb66397e2eec7b3e) Thanks [@davidamunga](https://github.com/davidamunga)! - Fix analytics sheets ignoring active export filters (e.g. exclude charges, sort order).
+- Fix analytics sheets ignoring active export filters (e.g. exclude charges, sort order). ([#65](https://github.com/davidamunga/mpesa2csv/pull/65))
 
-- [#65](https://github.com/davidamunga/mpesa2csv/pull/65) [`98f56be`](https://github.com/davidamunga/mpesa2csv/commit/98f56be85d73804181da370bfbb4a3eff1f38670) Thanks [@davidamunga](https://github.com/davidamunga)! - Fix multi-file batch losing already-processed statements when a mid-batch file requires a password.
+- Fix multi-file batch losing already-processed statements when a mid-batch file requires a password. ([#65](https://github.com/davidamunga/mpesa2csv/pull/65))
 
-- [#66](https://github.com/davidamunga/mpesa2csv/pull/66) [`1dfacf4`](https://github.com/davidamunga/mpesa2csv/commit/1dfacf4e67f72335730c6427e209063c23ab1e41) Thanks [@davidamunga](https://github.com/davidamunga)! - fix : dependencies security
+- fix : dependencies security ([#66](https://github.com/davidamunga/mpesa2csv/pull/66))
 
-- [#65](https://github.com/davidamunga/mpesa2csv/pull/65) [`98f56be`](https://github.com/davidamunga/mpesa2csv/commit/98f56be85d73804181da370bfbb4a3eff1f38670) Thanks [@davidamunga](https://github.com/davidamunga)! - Treat a parsed PDF with zero transactions as an error instead of showing a silent success screen.
+- Treat a parsed PDF with zero transactions as an error instead of showing a silent success screen. ([#65](https://github.com/davidamunga/mpesa2csv/pull/65))
 
-- [#65](https://github.com/davidamunga/mpesa2csv/pull/65) [`98f56be`](https://github.com/davidamunga/mpesa2csv/commit/98f56be85d73804181da370bfbb4a3eff1f38670) Thanks [@davidamunga](https://github.com/davidamunga)! - Kill the Java/Tabula process when PDF extraction times out instead of leaving it running in the background.
+- Kill the Java/Tabula process when PDF extraction times out instead of leaving it running in the background. ([#65](https://github.com/davidamunga/mpesa2csv/pull/65))
 
 ## 0.13.0
 
 ### Minor Changes
 
-- [`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f) Thanks [@davidamunga](https://github.com/davidamunga)! - feat: add recurring transactions export sheet
+- feat: add recurring transactions export sheet ([`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f))
 
-- [`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f) Thanks [@davidamunga](https://github.com/davidamunga)! - feat: add time of day export sheet
+- feat: add time of day export sheet ([`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f))
 
-- [`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f) Thanks [@davidamunga](https://github.com/davidamunga)! - feat: updated ui components
+- feat: updated ui components ([`8436074`](https://github.com/davidamunga/mpesa2csv/commit/84360748c8636025407f4fe32cc805b4d1ffed3f))
 
 ## 0.12.4
 
 ### Patch Changes
 
-- [`c5c2765`](https://github.com/davidamunga/mpesa2csv/commit/c5c2765906d794bfbbf71c10484a4d466e703f9a) Thanks [@davidamunga](https://github.com/davidamunga)! - fix: os build release fixes
+- fix: os build release fixes ([`c5c2765`](https://github.com/davidamunga/mpesa2csv/commit/c5c2765906d794bfbbf71c10484a4d466e703f9a))
 
 ## 0.12.1
 
 ### Patch Changes
 
-- [`1c8dd71`](https://github.com/davidamunga/mpesa2csv/commit/1c8dd71dfb0b603c0f4af2ca946ed73759ff7cac) Thanks [@davidamunga](https://github.com/davidamunga)! - fix: intel mac build
+- fix: intel mac build ([`1c8dd71`](https://github.com/davidamunga/mpesa2csv/commit/1c8dd71dfb0b603c0f4af2ca946ed73759ff7cac))
 
 ## 0.12.0
 
 ### Minor Changes
 
-- [#59](https://github.com/DavidAmunga/mpesa2csv/pull/59) [`dd6ea1b`](https://github.com/DavidAmunga/mpesa2csv/commit/dd6ea1b3200aed05737467b785c79d9a5e96da9d) Thanks [@DavidAmunga](https://github.com/DavidAmunga)! - feat: add total charges in header summary
+- feat: add total charges in header summary ([#59](https://github.com/DavidAmunga/mpesa2csv/pull/59))
 
 ## 0.11.4
 
 ### Patch Changes
 
-- [`c7be488`](https://github.com/DavidAmunga/mpesa2csv/commit/c7be4883974d76f33415e93ccb7daa05b54348fd) Thanks [@DavidAmunga](https://github.com/DavidAmunga)! - fix: windows build-jre folder path
+- fix: windows build-jre folder path ([`c7be488`](https://github.com/DavidAmunga/mpesa2csv/commit/c7be4883974d76f33415e93ccb7daa05b54348fd))
 
 ## 0.11.3
 
 ### Patch Changes
 
-- [`fa44fa8`](https://github.com/DavidAmunga/mpesa2csv/commit/fa44fa8d8d14de521626244d4f13a1a1aa1769dd) Thanks [@DavidAmunga](https://github.com/DavidAmunga)! - fix: windows jre folder bundling
+- fix: windows jre folder bundling ([`fa44fa8`](https://github.com/DavidAmunga/mpesa2csv/commit/fa44fa8d8d14de521626244d4f13a1a1aa1769dd))
 
 ## 0.11.2
 
 ### Patch Changes
 
-- [`2053a87`](https://github.com/DavidAmunga/mpesa2csv/commit/2053a8725c43a4fcd23ef5cb1e370dc8ceab20ea) Thanks [@DavidAmunga](https://github.com/DavidAmunga)! - revert:windows installers compression
+- revert:windows installers compression ([`2053a87`](https://github.com/DavidAmunga/mpesa2csv/commit/2053a8725c43a4fcd23ef5cb1e370dc8ceab20ea))
 
 ## 0.11.1
 
 ### Patch Changes
 
-- [`46ea850`](https://github.com/DavidAmunga/mpesa2csv/commit/46ea8502c794ce635ad6a7b988245a6ccfbda068) Thanks [@DavidAmunga](https://github.com/DavidAmunga)! - fix: improve JRE bundling verification for Windows and macOS installers
+- fix: improve JRE bundling verification for Windows and macOS installers ([`46ea850`](https://github.com/DavidAmunga/mpesa2csv/commit/46ea8502c794ce635ad6a7b988245a6ccfbda068))
 
 ## 0.11.0
 
@@ -136,10 +136,10 @@
 
 - 619f6e7: feat: added extra export formats
 
-  - JSON Export - Exports transactions in JSON format
-  - OFX Export - Exports transactions in OFX (Open Financial Exchange) format (Experimental)
-  - QFX Export - Exports transactions in QFX (Quicken Financial) format (Experimental)
-  - QIF Export - Exports transactions in QIF (Quicken Interchange) format (Experimental)
+ - JSON Export - Exports transactions in JSON format
+ - OFX Export - Exports transactions in OFX (Open Financial Exchange) format (Experimental)
+ - QFX Export - Exports transactions in QFX (Quicken Financial) format (Experimental)
+ - QIF Export - Exports transactions in QIF (Quicken Interchange) format (Experimental)
 
 ## 0.7.5
 
@@ -262,10 +262,10 @@
 
 - 68e265d: Add optional Charges/Fees sheet to Excel exports
 
-  - Add new export option to include a separate "Charges & Fees" sheet when exporting to Excel
-  - Filter and categorize all transactions containing "charge" in the details
-  - Display charges with date, amount, and balance information
-  - Include summary totals for total charges and number of charge transactions
+ - Add new export option to include a separate "Charges & Fees" sheet when exporting to Excel
+ - Filter and categorize all transactions containing "charge" in the details
+ - Display charges with date, amount, and balance information
+ - Include summary totals for total charges and number of charge transactions
 
 ## 0.0.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,7 +275,11 @@ This project uses [Changesets](https://github.com/changesets/changesets) for ver
    pnpm changeset
    ```
 
-2. **Follow the prompts** to describe your changes
+2. **Write a user-facing summary** — this becomes the changelog and GitHub release notes.
+   Prefer a complete sentence that explains the outcome for users, not a commit subject:
+
+   - Good: `Fix password-protected PDFs failing instead of showing the unlock prompt.`
+   - Avoid: `fix: password stuff` or thanking yourself in the summary
 
 3. **Commit the changeset** with your PR
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.1",
+    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.29.7",
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         version: 3.3.1
     devDependencies:
       '@changesets/changelog-github':
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: ^0.7.0
+        version: 0.7.0
       '@changesets/cli':
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.5.2)
@@ -258,8 +258,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.5.1':
-    resolution: {integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==}
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
 
   '@changesets/cli@2.29.7':
     resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
@@ -274,8 +274,8 @@ packages:
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  '@changesets/get-github-info@0.6.0':
-    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.13':
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
@@ -1962,9 +1962,9 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.5.1':
+  '@changesets/changelog-github@0.7.0':
     dependencies:
-      '@changesets/get-github-info': 0.6.0
+      '@changesets/get-github-info': 0.8.0
       '@changesets/types': 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
@@ -2024,7 +2024,7 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.7.2
 
-  '@changesets/get-github-info@0.6.0':
+  '@changesets/get-github-info@0.8.0':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "mpesa2csv"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,7 +54,7 @@ async fn extract_pdf_tables(
     output_path: String,
     password: Option<String>,
 ) -> Result<String, String> {
-    use std::process::Command;
+    use std::process::{Command, Stdio};
     use tauri::Manager;
     
     #[cfg(target_os = "windows")]
@@ -159,8 +159,16 @@ async fn extract_pdf_tables(
         .arg("all");
     
     if let Some(pwd) = password {
+        // Tabula long option is --password (short form is -s, not -p)
         cmd.arg("--password").arg(pwd);
     }
+
+    // Must pipe stdout/stderr before spawn so wait_with_output can capture
+    // Tabula errors (e.g. "Cannot decrypt PDF, the password is incorrect").
+    // Without this, GUI apps get empty Stderr/Stdout and password prompts never trigger.
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     
     let child = cmd
         .spawn()
@@ -204,9 +212,19 @@ async fn extract_pdf_tables(
     if output.status.success() {
         Ok(format!("Tables extracted successfully to: {}", output_path))
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        Err(format!("Tabula error:\nStderr: {}\nStdout: {}", stderr, stdout))
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!(
+                "Process exited with {} and no output",
+                output.status
+            )
+        };
+        Err(format!("Tabula error: {}", detail))
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ function App() {
   // Holds statements processed before a mid-batch password prompt so they
   // are not lost when handlePasswordSubmit runs (statements state is still []).
   const pendingStatements = useRef<MPesaStatement[]>([]);
+  // Keeps the password UI mounted (with Unlocking…) instead of jumping away.
+  const [isUnlocking, setIsUnlocking] = useState(false);
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
   const [appVersion, setAppVersion] = useState<string>("");
   const [downloadSuccess, setDownloadSuccess] = useState<boolean>(false);
@@ -116,6 +118,7 @@ function App() {
     setFiles(selectedFiles);
     setStatus(FileStatus.LOADING);
     setError(undefined);
+    setIsUnlocking(false);
     setStatements([]);
     setCurrentFileIndex(0);
     setPreviewExpanded(false);
@@ -189,11 +192,7 @@ function App() {
         if (cancelRequested.current) {
           return { cancelled: true, fileIndex: i, processedStatements };
         }
-        if (
-          err.message?.includes("password") ||
-          err.message?.includes("encrypted") ||
-          err.message?.includes("protected")
-        ) {
+        if (TabulaService.isPasswordError(err.message)) {
           setStatus(FileStatus.PROTECTED);
           return { needsPassword: true, fileIndex: i, processedStatements };
         }
@@ -258,7 +257,7 @@ function App() {
   const handlePasswordSubmit = async (password: string) => {
     if (files.length === 0) return;
 
-    setStatus(FileStatus.PROCESSING);
+    setIsUnlocking(true);
     setError(undefined);
 
     try {
@@ -279,6 +278,8 @@ function App() {
 
       const nextIndex = currentFileIndex + 1;
       if (nextIndex < files.length) {
+        setIsUnlocking(false);
+        setStatus(FileStatus.PROCESSING);
         const result = await processFiles(files, nextIndex, updatedStatements);
         if (result?.needsPassword) {
           // Another file in the batch needs a password; persist current progress.
@@ -288,6 +289,7 @@ function App() {
           setError(result.error);
         }
       } else {
+        setIsUnlocking(false);
         const combinedStatement = combineStatements(updatedStatements);
         const fileName = ExportService.getFileName(
           combinedStatement,
@@ -298,8 +300,13 @@ function App() {
         setStatus(FileStatus.SUCCESS);
       }
     } catch (err: any) {
+      setIsUnlocking(false);
       setStatus(FileStatus.PROTECTED);
-      setError(err.message || "Incorrect password. Please try again.");
+      setError(
+        TabulaService.isPasswordError(err.message)
+          ? "Incorrect password. Please try again."
+          : err.message || "Incorrect password. Please try again."
+      );
     }
   };
 
@@ -338,6 +345,7 @@ function App() {
     setFiles([]);
     setStatus(FileStatus.IDLE);
     setError(undefined);
+    setIsUnlocking(false);
     setStatements([]);
     setCurrentFileIndex(0);
     pendingStatements.current = [];
@@ -361,6 +369,7 @@ function App() {
     setStatements([]);
     setCurrentFileIndex(0);
     pendingStatements.current = [];
+    setIsUnlocking(false);
     setError(undefined);
   };
 
@@ -501,8 +510,11 @@ function App() {
         )}>
           <div className={cn(
             "w-full max-w-2xl transition-all duration-300 ease-in-out",
-            (status === FileStatus.IDLE || status === FileStatus.LOADING || status === FileStatus.ERROR)
-              && "flex flex-col flex-1"
+            (status === FileStatus.IDLE ||
+              status === FileStatus.LOADING ||
+              status === FileStatus.ERROR ||
+              status === FileStatus.PROTECTED) &&
+              "flex flex-col flex-1"
           )}>
             {status === FileStatus.IDLE ||
             status === FileStatus.LOADING ||
@@ -519,12 +531,13 @@ function App() {
                 )}
               </div>
             ) : status === FileStatus.PROTECTED ? (
-              <div className="transition-all duration-300">
+              <div className="flex flex-1 flex-col transition-all duration-300">
                 <PasswordPrompt
                   onPasswordSubmit={handlePasswordSubmit}
                   onSkip={handleSkipFile}
                   onReset={handleReset}
                   status={status}
+                  isUnlocking={isUnlocking}
                   error={error}
                   currentFileName={files[currentFileIndex]?.name}
                   currentFileIndex={currentFileIndex}

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { FileStatus } from "../types";
-import { Lock, Shield } from "lucide-react";
+import { FileText, Lock, Shield } from "lucide-react";
 import { cn } from "../lib/utils";
 import { PasswordInput } from "./ui/password-input";
 import { Button } from "./ui/button";
@@ -10,6 +10,8 @@ interface PasswordPromptProps {
   onSkip?: () => void;
   onReset?: () => void;
   status: FileStatus;
+  /** True while the current file is being decrypted — keeps this UI mounted. */
+  isUnlocking?: boolean;
   error?: string;
   currentFileName?: string;
   currentFileIndex?: number;
@@ -21,13 +23,25 @@ const PasswordPrompt: React.FC<PasswordPromptProps> = ({
   onSkip,
   onReset,
   status,
+  isUnlocking = false,
   error,
   currentFileName,
   currentFileIndex,
   totalFiles,
 }) => {
-  const [password, setPassword] = useState<string>("");
-  const isProcessing = status === FileStatus.PROCESSING;
+  const [password, setPassword] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const errorId = useId();
+  const isProcessing = isUnlocking || status === FileStatus.PROCESSING;
+  const isBatch = (totalFiles ?? 0) > 1;
+  const step = (currentFileIndex ?? 0) + 1;
+
+  useEffect(() => {
+    if (error) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [error]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,50 +51,74 @@ const PasswordPrompt: React.FC<PasswordPromptProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-5">
-      {/* Header */}
-      <div className="flex flex-col items-center gap-3 text-center">
-        <div className="rounded-2xl bg-muted/60 p-4 text-yellow-500">
-          <Lock className="size-8" strokeWidth={1.5} />
-        </div>
-
-        <div className="space-y-1">
-          <h3 className="text-base font-semibold">Password protected PDF</h3>
-          {totalFiles && totalFiles > 1 ? (
+    <div className="flex flex-1 flex-col justify-center gap-6">
+      <header className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Lock className="size-4 shrink-0" strokeWidth={1.75} />
+              <h2 className="text-base font-semibold text-foreground">
+                Password protected PDF
+              </h2>
+            </div>
             <p className="text-sm text-muted-foreground">
-              File {(currentFileIndex ?? 0) + 1} of {totalFiles}
+              {isBatch
+                ? `File ${step} of ${totalFiles} — decrypts on this device only`
+                : "Decrypts on this device only — nothing is uploaded"}
             </p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Enter the password to unlock and process this file
-            </p>
-          )}
+          </div>
         </div>
 
         {currentFileName && (
-          <span className="inline-block max-w-xs truncate rounded-full border border-border/60 bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
-            {currentFileName}
-          </span>
+          <div className="flex min-w-0 items-center gap-2 rounded-lg border border-border/60 px-3 py-2">
+            <FileText
+              className="size-4 shrink-0 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+            <p
+              className="min-w-0 truncate text-sm text-muted-foreground"
+              title={currentFileName}
+            >
+              {currentFileName}
+            </p>
+          </div>
         )}
-      </div>
+      </header>
 
-      {/* Form */}
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
         <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="statement-password"
+            className="text-sm font-medium text-foreground"
+          >
+            Password
+          </label>
           <PasswordInput
+            id="statement-password"
+            ref={inputRef}
             className={cn(
-              error
-                ? "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20"
-                : ""
+              "h-10",
+              error &&
+                "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20",
             )}
-            placeholder="Enter password"
+            placeholder="Statement password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             disabled={isProcessing}
             autoFocus
+            autoComplete="off"
+            spellCheck={false}
+            aria-invalid={Boolean(error)}
+            aria-describedby={error ? errorId : "password-hint"}
           />
-          {error && (
-            <p className="text-xs text-destructive">{error}</p>
+          {error ? (
+            <p id={errorId} role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : (
+            <p id="password-hint" className="text-xs text-muted-foreground">
+              Often the OTP code used when requesting the statement or National ID (for old statements)
+            </p>
           )}
         </div>
 
@@ -91,46 +129,55 @@ const PasswordPrompt: React.FC<PasswordPromptProps> = ({
         >
           {isProcessing ? (
             <>
-              <div className="animate-spin h-4 w-4 border-b-2 border-current rounded-full" />
+              <div className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
               Unlocking…
             </>
           ) : (
-            "Unlock PDF"
+            "Unlock & process"
           )}
         </Button>
 
         {(onSkip || onReset) && (
-          <div className="flex gap-2">
+          <div className="flex items-center justify-center gap-1">
             {onSkip && (
               <Button
                 type="button"
-                variant="outline"
-                className="flex-1"
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground"
                 onClick={onSkip}
                 disabled={isProcessing}
               >
-                Skip File
+                Skip file
               </Button>
+            )}
+            {onSkip && onReset && (
+              <span
+                aria-hidden
+                className="text-muted-foreground/40 select-none"
+              >
+                ·
+              </span>
             )}
             {onReset && (
               <Button
                 type="button"
-                variant="outline"
-                className="flex-1"
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground"
                 onClick={onReset}
                 disabled={isProcessing}
               >
-                Restart
+                Start over
               </Button>
             )}
           </div>
         )}
       </form>
 
-      {/* Privacy note */}
       <div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
-        <Shield className="w-3.5 h-3.5 shrink-0" />
-        <span>Password is only used locally to decrypt the file</span>
+        <Shield className="size-3.5 shrink-0" strokeWidth={1.75} />
+        <span>Password never leaves this device</span>
       </div>
     </div>
   );

--- a/src/services/tabulaService.ts
+++ b/src/services/tabulaService.ts
@@ -51,8 +51,24 @@ export class TabulaService {
           error,
         );
       }
-      throw new Error(`Tabula extraction failed: ${error.message || error}`);
+      const message =
+        typeof error === "string"
+          ? error
+          : error?.message || String(error);
+      throw new Error(`Tabula extraction failed: ${message}`);
     }
+  }
+
+  /** True when a Tabula/backend error indicates the PDF needs a password. */
+  static isPasswordError(message: string | undefined): boolean {
+    if (!message) return false;
+    const lower = message.toLowerCase();
+    return (
+      lower.includes("password") ||
+      lower.includes("encrypted") ||
+      lower.includes("decrypt") ||
+      lower.includes("protected")
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix password-protected PDFs failing with an empty Tabula error instead of showing the unlock prompt (pipe Java stderr/stdout, improve password-error detection)
- Refine the password-protected unlock UI and keep it mounted while decrypting
- Make changelog/GitHub release notes more professional: summary-first entries, no “Thanks!” attributions, simpler release body

## Test plan
- [x] Drop a password-protected M-PESA statement PDF and confirm the unlock prompt appears (not a red empty Tabula error)
- [x] Enter the correct password and confirm extraction succeeds
- [x] Enter an incorrect password and confirm a clear “Incorrect password” message
- [x] Skip file / Start over still work from the unlock screen
- [x] Confirm pending changesets are present for the next version bump